### PR TITLE
Add support for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The first step is getting the songs you want to import into Apple Music into a C
 If you want to export you whole Spotify library, simply create a new playlist called **All** and drag your whole library into it using the Spotify desktop app. You can then export the playlist **All** using **Exportify**. Save the resulting file as **spotify.csv** in the same directory as the directory you cloned this repo into.
 
 ### 2. Match the Spotify songs with their Apple Music identifier
-In order to add songs to our Apple Music playlist, we need their Apple Music identifier. Running `python3 retrieve-identifiers.py` will use the **spotify.csv** file to create a new file **itunes.csv** with each line consisting of the Apple Music identifier of a song in your Spotify playlist.
+In order to add songs to our Apple Music playlist, we need their Apple Music identifier. Running `python3 retrieveIdentifiers.py` will use the **spotify.csv** file to create a new file **itunes.csv** with each line consisting of the Apple Music identifier of a song in your Spotify playlist.
 And now, all songs that haven't match any Apple Music identifiers are added to a **noresult.txt** file.
 
 ### 3. Open Apple Music in Firefox
@@ -22,9 +22,14 @@ And now, all songs that haven't match any Apple Music identifiers are added to a
 * Here come the tricky part... Hold on, you can do it. Open a terminal and run `python3`. Then, quickly import [pyautogui](https://pypi.org/project/PyAutoGUI/). (Make sure you have it installed before)
 * Back in our browser, in the **Resend request** tab, you should see the payload of the request. Remove the song id (your payload should look like this: {"data":[{"id":"","type":"songs"}]} Please check because this step is important), and put your cursor right beetwen the 2 dobule quotes.
 * In the terminal, run `pyautogui.position()`. It should return a tuple with two numbers. Replace the numbers in the line 14 and in the line 17 with the numbers you got from the terminal.
-* Then, in your borwser, put your cursor above the send button, and run the same command in the terminal. Replace the numbers in the line 19 with the numbers you got from the terminal.
+* Then, in your browser, put your cursor above the send button, and run the same command in the terminal. Replace the numbers in the line 19 with the numbers you got from the terminal.
 
-Now you should be ready to go. When the script run, just select your browser window and wait for the magic to happen.
+Now you should be ready to go. Run the following:
+```bash
+python3 insertSongs.py
+```
+
+When the script runs, just select your browser window and wait for the magic to happen.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ And now, all songs that haven't match any Apple Music identifiers are added to a
 * Then, hit the Resend button. It should be on the top right of the **Headers** tab.
 * Here come the tricky part... Hold on, you can do it. Open a terminal and run `python3`. Then, quickly import [pyautogui](https://pypi.org/project/PyAutoGUI/). (Make sure you have it installed before)
 * Back in our browser, in the **Resend request** tab, you should see the payload of the request. Remove the song id (your payload should look like this: {"data":[{"id":"","type":"songs"}]} Please check because this step is important), and put your cursor right beetwen the 2 dobule quotes.
-* In the terminal, run `pyautogui.position()`. It should return a tuple with two numbers. Replace the numbers in the line 14 and in the line 17 with the numbers you got from the terminal.
-* Then, in your browser, put your cursor above the send button, and run the same command in the terminal. Replace the numbers in the line 19 with the numbers you got from the terminal.
+* In the terminal, run `pyautogui.position()`. It should return a tuple with two numbers. Replace the numbers in the line 18 and in the line 25 with the numbers you got from the terminal.
+* Then, in your browser, put your cursor above the send button, and run the same command in the terminal. Replace the numbers in the line 27 with the numbers you got from the terminal.
 
 Now you should be ready to go. Run the following:
 ```bash

--- a/insertSongs.py
+++ b/insertSongs.py
@@ -3,7 +3,10 @@ import sys
 import pyautogui
 
 print("BEFORE CONTINUING, BE SURE YOU HAVE COPIED THE FOLLOWING LINE IN THE CLIPBOARD:\n")
-print('{"data":[{"id":"","type":"songs"}]}\n')
+if sys.platform == "darwin":
+    print('{"data":[{"id":"","type":"songs"}]}\n')
+else:
+    print('{"data":[{"id":"ID","type":"songs"}]}\n')
 input("If you have copied the line, press enter to continue...")
 
 with open('itunes.csv') as itunes_identifiers_file:

--- a/insertSongs.py
+++ b/insertSongs.py
@@ -2,7 +2,7 @@ import time
 import pyautogui
 
 print("BEFORE OF ALL! BE SURE TO HAVE COPIED THE FOLLOWING LINE IN THE CLIPBOARD:\n")
-print('{"data":[{"id":"ID","type":"songs"}]}\n')
+print('{"data":[{"id":"","type":"songs"}]}\n')
 input("If you have copied the line, press enter to continue...")
 
 with open('itunes.csv') as itunes_identifiers_file:

--- a/insertSongs.py
+++ b/insertSongs.py
@@ -2,7 +2,7 @@ import time
 import sys
 import pyautogui
 
-print("BEFORE OF ALL! BE SURE TO HAVE COPIED THE FOLLOWING LINE IN THE CLIPBOARD:\n")
+print("BEFORE CONTINUING, BE SURE YOU HAVE COPIED THE FOLLOWING LINE IN THE CLIPBOARD:\n")
 print('{"data":[{"id":"","type":"songs"}]}\n')
 input("If you have copied the line, press enter to continue...")
 
@@ -12,16 +12,16 @@ with open('itunes.csv') as itunes_identifiers_file:
     for line in itunes_identifiers_file:
         itunes_identifier = int(line)
         print(f"\nAdding song with iTunes identifier {itunes_identifier}...")
-        pyautogui.click(<REMPLACE THIS>, <REMPLACE THIS>)
+        pyautogui.click(<REPLACE THIS>, <REPLACE THIS>)
         if sys.platform == "darwin":
             pyautogui.hotkey("command", "a")
             pyautogui.hotkey("command", "v")
         else:
             pyautogui.hotkey("ctrl", "a")
             pyautogui.hotkey("ctrl", "v")
-        pyautogui.click(<REMPLACE THIS>, <REMPLACE THIS>)
+        pyautogui.click(<REPLACE THIS>, <REPLACE THIS>)
         pyautogui.typewrite(str(itunes_identifier))
-        pyautogui.click(<REMPLACE THIS>, <REMPLACE THIS>)
+        pyautogui.click(<REPLACE THIS>, <REPLACE THIS>)
         time.sleep(2)
         print("Song added!")
 

--- a/insertSongs.py
+++ b/insertSongs.py
@@ -1,4 +1,5 @@
 import time
+import sys
 import pyautogui
 
 print("BEFORE OF ALL! BE SURE TO HAVE COPIED THE FOLLOWING LINE IN THE CLIPBOARD:\n")
@@ -12,8 +13,12 @@ with open('itunes.csv') as itunes_identifiers_file:
         itunes_identifier = int(line)
         print(f"\nAdding song with iTunes identifier {itunes_identifier}...")
         pyautogui.click(<REMPLACE THIS>, <REMPLACE THIS>)
-        pyautogui.hotkey("ctrl", "a")
-        pyautogui.hotkey("ctrl", "v")
+        if sys.platform == "darwin":
+            pyautogui.hotkey("command", "a")
+            pyautogui.hotkey("command", "v")
+        else:
+            pyautogui.hotkey("ctrl", "a")
+            pyautogui.hotkey("ctrl", "v")
         pyautogui.click(<REMPLACE THIS>, <REMPLACE THIS>)
         pyautogui.typewrite(str(itunes_identifier))
         pyautogui.click(<REMPLACE THIS>, <REMPLACE THIS>)


### PR DESCRIPTION
While running this script, it didn't quite work until I changed the specified hotkeys involved with Select All & Paste. These tweaks will make the `insertSongs.py` script work on Macs.

I also fixed up some typos and added some clarification to the README along the way.