### PR TITLE
Escape apostrophes in title, artist or album names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.csv
 *.txt
+*.dat

--- a/convertsongs.py
+++ b/convertsongs.py
@@ -142,7 +142,7 @@ with requests.Session() as s:
             n += 1
             # Trying to get the iTunes ID of the song
             title, artist, album = escape_apostrophes(
-                row[2]), escape_apostrophes(row[4]), escape_apostrophes(row[3])
+                row[1]), escape_apostrophes(row[3]), escape_apostrophes(row[5])
             track_id = get_itunes_id(title, artist, album)
             # If the song is found, add it to the playlist
             if track_id:

--- a/convertsongs.py
+++ b/convertsongs.py
@@ -13,12 +13,20 @@ else:
     print('\nCommand usage:\npython3 convertsongs.py yourplaylist.csv\nMore info at https://github.com/therealmarius/Spotify-2-AppleMusic')
     exit()
 
-# Getting user's data for the connection
-token = input("\nPlease enter your Apple Music Authorization (Bearer token):\n")
-media_user_token = input("\nPlease enter your media user token:\n")
-cookies = input("\nPlease enter your cookies:\n")
-playlist_identifier = input("\nPlease enter the playlist identifier:\n")
+# Function to get contents of file if it exists
+def get_connection_data(f,prompt):
+    if os.path.exists(f):
+        with open(f,'r') as file:
+            return file.read().rstrip('\n')
+    else:
+            return input(prompt)
 
+# Getting user's data for the connection
+token = get_connection_data("token.dat", "\nPlease enter your Apple Music Authorization (Bearer token):\n")
+media_user_token = get_connection_data("media_user_token.dat", "\nPlease enter your media user token:\n")
+cookies = get_connection_data("cookies.dat", "\nPlease enter your cookies:\n")
+
+playlist_identifier = input("\nPlease enter the playlist identifier:\n")
 
 # function to escape apostrophes
 def escape_apostrophes(s):

--- a/convertsongs.py
+++ b/convertsongs.py
@@ -19,6 +19,11 @@ media_user_token = input("\nPlease enter your media user token:\n")
 cookies = input("\nPlease enter your cookies:\n")
 playlist_identifier = input("\nPlease enter the playlist identifier:\n")
 
+
+# function to escape apostrophes
+def escape_apostrophes(s):
+    return s.replace("'", "\\'")
+
 # Function to get the iTunes ID of a song
 def get_itunes_id(title, artist, album):
     BASE_URL = "https://itunes.apple.com/search?country=FR&media=music&entity=song&limit=5&term="
@@ -136,7 +141,8 @@ with requests.Session() as s:
         for row in file:
             n += 1
             # Trying to get the iTunes ID of the song
-            title, artist, album =  row[1], row[3], row[5]
+            title, artist, album = escape_apostrophes(
+                row[2]), escape_apostrophes(row[4]), escape_apostrophes(row[3])
             track_id = get_itunes_id(title, artist, album)
             # If the song is found, add it to the playlist
             if track_id:


### PR DESCRIPTION
Tracks having apostrophes in the Title, Artist or Album names were failing to be found in the search. Escaping these characters avoids the issue.