### PR TITLE
Check for best equivalent song_id to avoid 500 Internal Server errors when adding songs to playlist

### DIFF
--- a/convertsongs.py
+++ b/convertsongs.py
@@ -159,8 +159,25 @@ def match_isrc_to_itunes_id(session, album, album_artist, isrc):
     except:
         return None
 
+def fetch_equivalent_itunes_id(session, song_id):
+    try:
+        request = session.get(f"https://amp-api.music.apple.com/v1/catalog/{country_code}/songs?filter[equivalents]={song_id}")
+        if request.status_code == 200:
+            data = json.loads(request.content.decode('utf-8'))
+            return data['data'][0]['id']
+        else:
+            return song_id
+    except:
+        return song_id
+
+
 # Function to add a song to a playlist
 def add_song_to_playlist(session, song_id, playlist_id):
+    song_id=str(song_id)
+    equivalent_itunes_id = fetch_equivalent_itunes_id(session, song_id)
+    if equivalent_itunes_id != song_id: 
+        print(f"{song_id} switched to equivalent -> {equivalent_itunes_id}")
+        song_id = equivalent_itunes_id
     try:   
         request = session.post(f"https://amp-api.music.apple.com/v1/me/library/playlists/{playlist_id}/tracks", json={"data":[{"id":f"{song_id}","type":"songs"}]})
         # Checking if the request is successful


### PR DESCRIPTION
Because for a small number of songs we get an error when trying to add them, it seems that the search is sometimes resulting in songs which are not available (in the user's own country) trying to be added. 

This adds a check for for equivalent song_id, just before trying to add it to the playlist.

It turns out that:
- if the song is available, the returned equivalent_id is the same as the one we input and we simply continue to add it as before
- if the song is not available, it returns an id which is the same song / artist / album, but is available, and we can reliably add that instead.

In my testing, the equavalent_id  was always successfully added to the playlist, and was the correct song from the correct album.